### PR TITLE
[Fix] タイムゾーンを日本時間に変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,7 @@ module NaganoCake
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone (:local)
   end
 end


### PR DESCRIPTION
デフォルトだと９時間の誤差（時差）があり、
・過去のログを確認する時いつのログなのかで逆算するのに手間がかかる
・今後商品や会員登録で登録・更新時に影響が出るかな

と思い、担当機能と関係ありませんが日本時間に変更してみました。（これによって今後不具合が生じたら即変更します。）

config/application.rbファイルに以下の記述追加
①config.time_zone = 'Tokyo'
②config.active_record.default_timezone (:local)

①ブラウザ上での表示の時間設定→商品の投稿した時間などブラウザで表示する際に影響します
②データベースの時間設定→ターミナルのログ時間などで影響します

参考のサイトはスラックに貼ります。